### PR TITLE
For object element not trigger

### DIFF
--- a/src/content/snaplinks.js
+++ b/src/content/snaplinks.js
@@ -168,7 +168,9 @@ var SnapLinksClass = Class.create({
 			return false;
 		if(SLPrefs.Activation.RequiresCtrl != e.ctrlKey)
 			return false;
-		return e.target.tagName != 'EMBED';
+		if(e.target.tagName == 'EMBED' || e.target.tagName == 'OBJECT')
+			return false;
+		return true;
 
 	},
 


### PR DESCRIPTION
Fix inappropriate trigger for object element have `Opaque=wmode` propertie.

Test case (for the No.3):
```html
<embed width="100" height="100" src="http://www.w3schools.com/html/bookmark.swf">1
<object width="100" height="100" data="http://www.w3schools.com/html/bookmark.swf"></object>2
<object width="100" height="100" data="http://www.w3schools.com/html/bookmark.swf"><param value="Opaque" name="wmode"></object>3
```