### PR TITLE
Change tab opening order

### DIFF
--- a/src/background-scripts/background.js
+++ b/src/background-scripts/background.js
@@ -46,7 +46,7 @@ function onMessage(msg, sender, respond) {
 					let props = {
 						url:    url,
 						active: Prefs.SwitchFocusToNewTab ? (--TabsLeft) === 0 : false,	// Activate the last tab to be opened
-						index:  Prefs.OpenTabsAtEndOfTabBar ? tabsAll.length + nbOpened++ : tabs[0].index + 1 + nbOpened++, // Open tabs at the end of the tab bar
+						index:  (Prefs.OpenTabsAtEndOfTabBar ? tabsAll.length : tabs[0].index + 1) + nbOpened++, // Open tabs at the end of the tab bar
 					};
 					if(isFirefox) {
 						props.cookieStoreId = tabs[0].cookieStoreId;

--- a/src/background-scripts/background.js
+++ b/src/background-scripts/background.js
@@ -41,12 +41,12 @@ function onMessage(msg, sender, respond) {
 					return;
 				let TabsLeft = msg.tUrls.length;
 
-				// Reverse the url order so that we are opening in the correct order
-				for(let url of msg.tUrls.reverse()) {
+				let nbOpened = 0;
+				for(let url of msg.tUrls) {
 					let props = {
 						url:    url,
 						active: Prefs.SwitchFocusToNewTab ? (--TabsLeft) === 0 : false,	// Activate the last tab to be opened
-						index:  Prefs.OpenTabsAtEndOfTabBar ? tabsAll.length : tabs[0].index + 1, // Open tabs at the end of the tab bar
+						index:  Prefs.OpenTabsAtEndOfTabBar ? tabsAll.length + nbOpened++ : tabs[0].index + 1 + nbOpened++, // Open tabs at the end of the tab bar
 					};
 					if(isFirefox) {
 						props.cookieStoreId = tabs[0].cookieStoreId;


### PR DESCRIPTION
Closes #291 
With a delay it can cause a strange behavior: I'm using 2 tabs
`MyCurrentTab ASecondTab`
If I open 3 links (1 2 3) I'll obtain this behavior:
```
MyCurrentTab ASecondTab
MyCurrentTab 1 ASecondTab
MyCurrentTab 1 2 ASecondTab
MyCurrentTab 1 2 3 ASecondTab
```
That's normal. With a delay I can close 2 before that 3 is opened and this happens:
```
MyCurrentTab ASecondTab
MyCurrentTab 1 ASecondTab
MyCurrentTab 1 2 ASecondTab
MyCurrentTab 1 ASecondTab <- here I close 2
MyCurrentTab 1 ASecondTab 3
```

Even a little delay can cause that if I have more than 3 links.

We could count tabs that have been closed to avoid this. I was thinking of leaving a TODO in code or opening an issue if this is merge.