### PR TITLE
correct 'Height' when website gives 0

### DIFF
--- a/src/content-scripts/ElementIndexer.js
+++ b/src/content-scripts/ElementIndexer.js
@@ -245,9 +245,9 @@ class ElementIndexer {
 	 * Updates the index of this.Elements separated into N buckets for quickly paring down the elements to be checked for intersection of the selection rectangle
 	 */
 	UpdateIndex() {
-		let docHeight = docElem.scrollHeight,
-			Buckets   = Prefs.IndexBuckets,
-			offset    = { x: window.scrollX, y: window.scrollY },
+		let [docWidth, docHeight] = GetDocumentDims();
+		let	Buckets = Prefs.IndexBuckets,
+			offset  = {x: window.scrollX, y: window.scrollY},
 			rr;
 
 		this.ElemChecks = new Map();

--- a/src/content-scripts/ElementIndexer.js
+++ b/src/content-scripts/ElementIndexer.js
@@ -339,8 +339,16 @@ class ElementIndexer {
 		if(Prefs.Debug_Measure_SearchSpeed)
 			rr = new RateReporter('Found ${Count} Elements in ${Elapsed} (${PerSecond})');
 
-		let docHeight   = document.documentElement.scrollHeight,
-			Buckets     = Prefs.IndexBuckets,
+			let docHeight = document.documentElement.scrollHeight;
+			// To handle some websites (#288)
+			if(docHeight == 0) {
+				docHeight = Math.max(
+					document.body.scrollHeight, document.documentElement.scrollHeight,
+					document.body.offsetHeight, document.documentElement.offsetHeight,
+					document.body.clientHeight, document.documentElement.clientHeight
+				);
+			}
+			let Buckets = Prefs.IndexBuckets,
 			FirstBucket = Math.floor(sel.top * Buckets / docHeight),
 			LastBucket  = Math.floor(sel.bottom * Buckets / docHeight),
 			offset      = { x: window.scrollX, y: window.scrollY },

--- a/src/content-scripts/ElementIndexer.js
+++ b/src/content-scripts/ElementIndexer.js
@@ -339,15 +339,7 @@ class ElementIndexer {
 		if(Prefs.Debug_Measure_SearchSpeed)
 			rr = new RateReporter('Found ${Count} Elements in ${Elapsed} (${PerSecond})');
 
-			let docHeight = document.documentElement.scrollHeight;
-			// To handle some websites (#288)
-			if(docHeight == 0) {
-				docHeight = Math.max(
-					document.body.scrollHeight, document.documentElement.scrollHeight,
-					document.body.offsetHeight, document.documentElement.offsetHeight,
-					document.body.clientHeight, document.documentElement.clientHeight
-				);
-			}
+			let [docWidth, docHeight] = GetDocumentDims();
 			let Buckets = Prefs.IndexBuckets,
 			FirstBucket = Math.floor(sel.top * Buckets / docHeight),
 			LastBucket  = Math.floor(sel.bottom * Buckets / docHeight),

--- a/src/content-scripts/EventHandler.js
+++ b/src/content-scripts/EventHandler.js
@@ -146,18 +146,10 @@ class EventHandler {
 	onMouseMoveInterval() {
 		let e = this.LastMouseEvent;
 
-		let docHeight = docElem.scrollHeight;
-		// To handle some websites (#288)
-		if(docHeight == 0) {
-			docHeight = Math.max(
-				document.body.scrollHeight, docElem.scrollHeight,
-				document.body.offsetHeight, docElem.offsetHeight,
-				document.body.clientHeight, docElem.clientHeight
-			);
-    }
+		let [docWidth, docHeight] = GetDocumentDims();
 
-    if(!this.docSize || this.docSize.x != docElem.scrollWidth || this.docSize.y != docHeight) {
-			this.docSize = {x: docElem.scrollWidth, y: docHeight};
+    if(!this.docSize || this.docSize.x != docWidth || this.docSize.y != docHeight) {
+			this.docSize = {x: docWidth, y: docHeight};
     }
 
 		let [clientWidth, clientHeight] = GetClientDims();

--- a/src/content-scripts/EventHandler.js
+++ b/src/content-scripts/EventHandler.js
@@ -108,7 +108,13 @@ class EventHandler {
 	 */
 	BeginDrag(e) {
 		this.FirstInit();
-		this.CurrentSelection.SetOrigin(e.pageY, e.pageX);
+		let [clientWidth, clientHeight] = GetClientDims();
+		this.MousePos = { clientX: e.clientX, clientY: e.clientY };
+		this.CurrentSelection.SetOrigin(
+			window.scrollY + Math.min(this.MousePos.clientY, clientHeight),
+			window.scrollX + Math.min(this.MousePos.clientX, clientWidth)
+		);
+		// this.CurrentSelection.SetOrigin(e.pageY, e.pageX);
 
 		this.LastMouseEvent = e;
 
@@ -140,10 +146,19 @@ class EventHandler {
 	onMouseMoveInterval() {
 		let e = this.LastMouseEvent;
 
-		if(!this.docSize || this.docSize.x != docElem.scrollWidth || this.docSize.y != docElem.scrollHeight) {
-			this.docSize = { x: docElem.scrollWidth, y: docElem.scrollHeight };
-			pub(DocSizeChanged, this.docSize);
-		}
+		let docHeight = docElem.scrollHeight;
+		// To handle some websites (#288)
+		if(docHeight == 0) {
+			docHeight = Math.max(
+				document.body.scrollHeight, docElem.scrollHeight,
+				document.body.offsetHeight, docElem.offsetHeight,
+				document.body.clientHeight, docElem.clientHeight
+			);
+    }
+
+    if(!this.docSize || this.docSize.x != docElem.scrollWidth || this.docSize.y != docHeight) {
+			this.docSize = {x: docElem.scrollWidth, y: docHeight};
+    }
 
 		let [clientWidth, clientHeight] = GetClientDims();
 

--- a/src/content-scripts/SelectionRect.js
+++ b/src/content-scripts/SelectionRect.js
@@ -124,16 +124,8 @@ class Rect {
 class DocRect extends Rect {
 	constructor(doc) {
     let docElem = document.documentElement;
-    let docHeight = docElem.scrollHeight;
-    // To handle some websites (#288)
-    if(docHeight == 0) {
-      docHeight = Math.max(
-        document.body.scrollHeight, docElem.scrollHeight,
-        document.body.offsetHeight, docElem.offsetHeight,
-        document.body.clientHeight, docElem.clientHeight
-      );
-    }
-    super(0, 0, docHeight, docElem.scrollWidth);
+    let [docWidth, docHeight] = GetDocumentDims();
+    super(0, 0, docHeight, docWidth);
 	}
 }
 

--- a/src/content-scripts/SelectionRect.js
+++ b/src/content-scripts/SelectionRect.js
@@ -123,8 +123,17 @@ class Rect {
  */
 class DocRect extends Rect {
 	constructor(doc) {
-		let docElem = document.documentElement;
-		super(0, 0, docElem.scrollHeight, docElem.scrollWidth);
+    let docElem = document.documentElement;
+    let docHeight = docElem.scrollHeight;
+    // To handle some websites (#288)
+    if(docHeight == 0) {
+      docHeight = Math.max(
+        document.body.scrollHeight, docElem.scrollHeight,
+        document.body.offsetHeight, docElem.offsetHeight,
+        document.body.clientHeight, docElem.clientHeight
+      );
+    }
+    super(0, 0, docHeight, docElem.scrollWidth);
 	}
 }
 

--- a/src/content-scripts/SelectionRect.js
+++ b/src/content-scripts/SelectionRect.js
@@ -143,12 +143,12 @@ class SelectionRect {
 			this.StyleNode = CreateElement(`
 				<style>
 					.SnapLinksContainer :not([xyz]) {  }
-					.SnapLinksContainer .SnapLinksHighlighter { 
-						all: initial; overflow: visible; 
-						position: absolute; top: 0px; left: 0px; width: 10px; height: 10px;  
+					.SnapLinksContainer .SnapLinksHighlighter {
+						all: initial; overflow: visible;
+						position: absolute; top: 0px; left: 0px; width: 10px; height: 10px;
 					}
-					.SnapLinksContainer { 
-						pointer-events: none; z-index: 999999;  
+					.SnapLinksContainer {
+						pointer-events: none; z-index: 999999;
 						position: absolute; top: 0px; left: 0px; margin: 0px; padding: 0px; height: 0px; width: 0px; }
 					.SnapLinksContainer > .SL_SelectionRect { outline: 2px dashed rgba(0,200,0,1); position: absolute; overflow: visible; z-index: 1; }
 					.SL_SelectionRect > .SL_SelectionLabel { position: absolute; background: #FFFFD9; border: 1px solid black; border-radius: 2px; padding: 2px; font: normal 12px Verdana; white-space: nowrap; color: #000000; }
@@ -212,7 +212,7 @@ class SelectionRect {
 		let dr = (new DocRect(document))
 			.Expand(-2, -2);
 
-		let { width, height } = this.dims;
+		let {width, height} = this.dims;
 
 		/* Based on current fixed style */
 		this.dims
@@ -285,7 +285,7 @@ class SelectionRect {
 	 * @returns {boolean}
 	 */
 	IsLargeEnoughToActivate() {
-		return this.dims.width > Prefs.Activation_MinX || this.dims.height > Prefs.Activation_MinY;
+		return this.dims.width > Prefs.Activation_Min || this.dims.height > Prefs.Activation_Min;
 	}
 
 	/**

--- a/src/content-scripts/Utility.js
+++ b/src/content-scripts/Utility.js
@@ -122,10 +122,6 @@ function GetClientDims() {
  * @returns {[number,number]}
  */
 function GetDocumentDims() {
-	let clientHeight = docElem.clientHeight,
-		clientWidth  = docElem.clientWidth;
-	// To handle some websites (#288)
-
 	let docHeight = docElem.scrollHeight,
 		docWidth  = docElem.scrollWidth;
 	// To handle some websites (#288)

--- a/src/content-scripts/Utility.js
+++ b/src/content-scripts/Utility.js
@@ -107,9 +107,41 @@ function GetClientDims() {
 	if(clientWidth == 0) {
 		clientWidth  = window.innerWidth - 12; // -12 allows to scroll
 	}
-	if(document.documentElement.clientHeight > window.innerHeight) {
+	if(docElem.clientHeight > window.innerHeight) {
 		clientHeight = document.body.clientHeight;
+	}
+	if(docElem.clientWidth > window.innerWidth) {
 		clientWidth  = document.body.clientWidth;
 	}
 	return [clientWidth, clientHeight];
+}
+
+/**
+ * Returns the document dimensions, adjusting for various situations
+ *
+ * @returns {[number,number]}
+ */
+function GetDocumentDims() {
+	let clientHeight = docElem.clientHeight,
+		clientWidth  = docElem.clientWidth;
+	// To handle some websites (#288)
+
+	let docHeight = docElem.scrollHeight,
+		docWidth  = docElem.scrollWidth;
+	// To handle some websites (#288)
+	if(docHeight == 0) {
+		docHeight = Math.max(
+			document.body.scrollHeight, docElem.scrollHeight,
+			document.body.offsetHeight, docElem.offsetHeight,
+			document.body.clientHeight, docElem.clientHeight
+		);
+	}
+	if(docWidth == 0) {
+		docWidth = Math.max(
+			document.body.scrollWidth, docElem.scrollWidth,
+			document.body.offsetWidth, docElem.offsetWidth,
+			document.body.clientWidth, docElem.clientWidth
+		);
+	}
+	return [docWidth, docHeight];
 }

--- a/src/content-scripts/Utility.js
+++ b/src/content-scripts/Utility.js
@@ -100,10 +100,16 @@ function AddModsToEvent(e) {
 function GetClientDims() {
 	let clientHeight = docElem.clientHeight,
 		clientWidth  = docElem.clientWidth;
-
+	// To handle some websites (#288)
+	if(clientHeight == 0) {
+		clientHeight = window.innerHeight - 12; // -12 allows to scroll
+	}
+	if(clientWidth == 0) {
+		clientWidth  = window.innerWidth - 12; // -12 allows to scroll
+	}
 	if(document.documentElement.clientHeight > window.innerHeight) {
 		clientHeight = document.body.clientHeight;
 		clientWidth  = document.body.clientWidth;
 	}
-	return [ clientWidth, clientHeight ];
+	return [clientWidth, clientHeight];
 }

--- a/src/globals.js
+++ b/src/globals.js
@@ -32,8 +32,7 @@ const DefaultPrefs = {
 	IndexBuckets: 10,
 	ScrollRate:   8,
 
-	Activation_MinX: 5,
-	Activation_MinY: 5,
+	Activation_Min: 5,
 
 	SelectionLabel_CursorMargin: 2,
 

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -47,7 +47,7 @@
 		<option value="4">Middle Click</option>
 		<option value="2">Right Click</option>
 	</select>
-	<span>and Drag</span>
+	<span>and Drag for <input type="text" size="2" id="Activation_Min"> pixels</span>
 </label>
 
 <label title="Always open tabs at the end of the tab bar.">


### PR DESCRIPTION
Closes #288 #263 

Some websites give `0` as `document.documentElement.scrollHeight` and `document.documentElement.clientHeight`. When that's the case I used [this](https://javascript.info/size-and-scroll-window#width-height-of-the-document) method. Except for `GetClientDims()` where I explicitly comment the reason why.