### PR TITLE
Share a single queue for each OPEN_URLS_IN_TABS action

### DIFF
--- a/src/background-scripts/background.js
+++ b/src/background-scripts/background.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let openUrlsPromiseChain = Promise.resolve();
 let TabStacks = new Map();
 
 /**
@@ -30,7 +31,9 @@ function onMessage(msg, sender, respond) {
 			browser.runtime.reload();
 			break;
 		case OPEN_URLS_IN_TABS:
-			OpenUrlsInTabs(msg.tUrls);
+			openUrlsPromiseChain = openUrlsPromiseChain.then(() => {
+				return OpenUrlsInTabs(msg.tUrls);
+			});
 			break;
 		case COPY_TO_CLIPBOARD:
 			CopyToClipboard(msg.tUrls);


### PR DESCRIPTION
I manually tested this in FireFox and it seems to work the way I want, though I use this add-on in a consistent way, so there are probably many use cases I'm not considering. I tested my typical scenario, which is described in detail in issue #529. 

I've been using my branch for a week+ now, and I haven't run into any bugs yet. 

As for the PR, my biggest concern is the name of that new variable: `openUrlsPromiseChain`. It feels like a bad name but I can't think of a better one.

Fixes #529 