### PR TITLE
feat-427: Open new tabs in background unloaded. FF only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ yarn.lock
 /.idea/dataSources/f52445c1-e86a-4ff7-a261-e80384b21567.xml
 /.idea/GitLink.xml
 SnapLinksDev
+.vscode/

--- a/src/background-scripts/background.js
+++ b/src/background-scripts/background.js
@@ -113,6 +113,8 @@ async function OpenUrlsInTabs(urls) {
 			props.cookieStoreId = activeTab.cookieStoreId;
 			if(Prefs.SetOwnershipTabID_FF)
 				props.openerTabId = activeTab.id;
+			if(Prefs.NewTabsOpenUnloaded)
+				props.discarded = true;
 		}
 
 		let newTab = await browser.tabs.create(props);

--- a/src/globals.js
+++ b/src/globals.js
@@ -55,6 +55,7 @@ const DefaultPrefs = {
 
 	OpenTabs:            TABS_OPEN_NATURAL,
 	DefaultAction:       OPEN_LINKS,
+	NewTabsOpenUnloaded: false,
 	SwitchFocusToNewTab: true,
 	ShowNumberOfLinks:   true,
 	ActivateModifiers:   NONE,

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -99,30 +99,30 @@
 <details id="UI_AdvancedOptions_Section">
 	<summary>Advanced Settings</summary>
 
-		<label title="Ignore font weight of elements when filtering.
-  &bull;  Holding alt while selecting disables filtering as well.">
-			<input id="DisableFontWeightFiltering" type="checkbox"> Disable link filtering by font weight
-			<img class="Info" alt="Additional Info" src="../../res/Info16.png" title="Holding alt while selecting disables filtering as well."/>
-		</label>
+	<label title="Ignore font weight of elements when filtering.
+&bull;  Holding alt while selecting disables filtering as well.">
+		<input id="DisableFontWeightFiltering" type="checkbox"> Disable link filtering by font weight
+		<img class="Info" alt="Additional Info" src="../../res/Info16.png" title="Holding alt while selecting disables filtering as well."/>
+	</label>
 
 	<label browsers="FireFox" title="This sets the opening tab id on newly opened tabs to maintain parent/child relationships between tabs.">
 		<input id="SetOwnershipTabID_FF" type="checkbox"> Set opening tab property for new tabs
 		<img class="Info" alt="Additional Info" src="../../res/Info16.png" title="This affects tab closing behavior, compatibility with TreeStyleTabs."/>
 		<img class="Info" alt="Firefox Only" src="../../res/FireFox16.png" title="This only works in FireFox."/>
-		</label>
+	</label>
 
-		<label title="Wait this many milliseconds between each new tab that is opened.">
-			Delay between new tabs: <input type="text" size="2" id="NewTabDelayMS"> ms
-		</label>
+	<label title="Wait this many milliseconds between each new tab that is opened.">
+		Delay between new tabs: <input type="text" size="2" id="NewTabDelayMS"> ms
+	</label>
 
-		<label title="Wait this many milliseconds between each element being clicked.">
-			Delay between clicks on elements: <input type="text" size="2" id="ClickDelayMS"> ms
-		</label>
+	<label title="Wait this many milliseconds between each element being clicked.">
+		Delay between clicks on elements: <input type="text" size="2" id="ClickDelayMS"> ms
+	</label>
 
-		<select id="StorageAPI" title="Syncronize your settings across all Firefox browsers or use Local Storage?">
-			<option value="sync">Sync storage</option>
-			<option value="local">Local storage</option>
-		</select>
+	<select id="StorageAPI" title="Syncronize your settings across all Firefox browsers or use Local Storage?">
+		<option value="sync">Sync storage</option>
+		<option value="local">Local storage</option>
+	</select>
 
 	<details id="UI_DevOptions_Section">
 		<summary>Developer Options</summary>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -83,6 +83,11 @@
 
 <div class="flex-list" style="height: 64px;">
 
+	<label browsers="FireFox" title="Open new tabs in background unloaded.">
+		<input id="NewTabsOpenUnloaded" type="checkbox"> Open in background unloaded
+		<img class="Info" alt="Firefox Only" src="../../res/FireFox16.png" title="This only works in FireFox."/>
+	</label>
+
 	<label title="Switch focus to the closest new tab when opening tabs.">
 		<input id="SwitchFocusToNewTab" type="checkbox"> Switch focus to new tab
 	</label>


### PR DESCRIPTION
1. This only works in Firefox, so I did not mark this pull request as closing the feature. 
2. The new property is named `NewTabsOpenUnloaded`
3. I used `SetOwnershipTabID_FF` as a frame of reference, but I didn't put the `_FF` suffix on the new property: I figured if another browser decides to make this possible, we wouldn't want to create a new property for that. We would just include it to work like Firefox already does.
4. This didn't seem like an advanced option to me, so I made it the first check box. 
5. I included two unrelated commits to this PR:
    1. Local VS Code settings are `.gitignored`. I prefer spaces over tabs, so I didn't want to change that setting globally, only for this repository. 
    2. I formatted the `UI_AdvancedOptions_Section` in the `options.htm`

Screenshot (note: I changed the label since to be `Open new tabs in background unloaded.`:
<img width="1069" height="1383" alt="image" src="https://github.com/user-attachments/assets/8c577e0f-5992-4125-b4ce-c8a91ad68114" />

Relates to #427 