### PR TITLE
fix: Update broken MDN links to new URL structure

### DIFF
--- a/docs/Links.md
+++ b/docs/Links.md
@@ -14,7 +14,7 @@
 
 [>>SnapLinksLogo]: images/SnapLinksLogo.png
 
-[MDN-Ext-Anatomy]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
+[MDN-Ext-Anatomy]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
 [FF-DevEd]: https://www.mozilla.org/firefox/developer/
 
 [>>Welcome]: README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ Please see the [Contributing][>>Contributing] document for more information.
 
 ## Background on Snap Links 3
 
-Snap Links Plus is being re-written from the ground up to be a [Web Extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions).
+Snap Links Plus is being re-written from the ground up to be a [Web Extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).
 
 This means some legacy features may no longer exist while other new features are written.
 


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates broken MDN URLs from the old format to the new format.

**Changes:**
- Old URL: `https://developer.mozilla.org/en-US/Add-ons/...`
- New URL: `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...`

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*