### PR TITLE
fix: Update deprecated MDN links to new format

### DIFF
--- a/docs/Links.md
+++ b/docs/Links.md
@@ -14,7 +14,7 @@
 
 [>>SnapLinksLogo]: images/SnapLinksLogo.png
 
-[MDN-Ext-Anatomy]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
+[MDN-Ext-Anatomy]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension
 [FF-DevEd]: https://www.mozilla.org/firefox/developer/
 
 [>>Welcome]: README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ Please see the [Contributing][>>Contributing] document for more information.
 
 ## Background on Snap Links 3
 
-Snap Links Plus is being re-written from the ground up to be a [Web Extension](https://developer.mozilla.org/en-US/Add-ons/WebExtensions).
+Snap Links Plus is being re-written from the ground up to be a [Web Extension](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions).
 
 This means some legacy features may no longer exist while other new features are written.
 


### PR DESCRIPTION
## Summary

Mozilla restructured developer.mozilla.org paths. This PR updates deprecated MDN links to the new format.

## Changes

- https://developer.mozilla.org/en-US/Add-ons/WebExtensions -> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions
- https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension -> https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension

## Why

The old URLs still redirect, but the new format is cleaner and ensures long-term compatibility.